### PR TITLE
added github action to run on macos-11

### DIFF
--- a/.github/workflows/unittest_pytest_coverage_doc.yml
+++ b/.github/workflows/unittest_pytest_coverage_doc.yml
@@ -222,9 +222,6 @@ jobs:
 
   macos-11_test:
     # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
-    if: ${{ false }}
-    # https://github.com/actions/virtual-environments/issues/2486
-    # https://github.com/actions/virtual-environments/blob/main/docs/macos-11-onboarding.md
     runs-on: macos-11
     needs: [pep8_check, pre-commit]
     steps:


### PR DESCRIPTION
macos-11 is available for everyone since August 2021 and [will become macos-latest](https://github.com/actions/virtual-environments/issues/4060).

macos-11 was not available before: actions/virtual-environments/issues/2486